### PR TITLE
Completed Json Validation on coordinates

### DIFF
--- a/Controllers/DesignsController.cs
+++ b/Controllers/DesignsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.Sqlite;
 using EnergyDesignSimulator.Models;
 using System.Text.Json;
+using EnergyDesignSimulator.Utility;
 
 namespace EnergyDesignSimulator.Controllers
 {
@@ -48,6 +49,7 @@ namespace EnergyDesignSimulator.Controllers
         [HttpPost]
         public async Task<IActionResult> CreateDesign([FromBody] Design design)
         {
+            if (!JsonValidator.IsValidJson(design.Coordinates)) return BadRequest("Invalid JSON");
             if (!ModelState.IsValid || design.PanelCount <= 0 || string.IsNullOrEmpty(design.LayoutName))
                 return BadRequest("Invalid design data");
 

--- a/Utility/utility.cs
+++ b/Utility/utility.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+namespace EnergyDesignSimulator.Utility
+{
+    public static class JsonValidator
+    {
+        public static bool IsValidJson(string jsonString)
+        {
+            if (string.IsNullOrEmpty(jsonString))
+            {
+                return false;
+            }
+
+            try
+            {
+                using (JsonDocument document = JsonDocument.Parse(jsonString))
+                {
+                    // If parsing succeeds, the JSON is valid
+                    return true;
+                }
+            }
+            catch (JsonException)
+            {
+                // If parsing fails, the JSON is invalid
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tested in postman which produces error when coordinates json is not valid. However in future we need to add numeric check to prevent someone putting alphanumeric or characters instead of valid coordinates. as of now this is only checking for valid jason using System.Text.Json as given in the problem statement.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/7d75ec94-d313-4b6e-b786-5f49d4e80b89" />
